### PR TITLE
Fix typo preventing example code from running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ new ZoomableWidget(
   minScale: 0.3,
   maxScale: 2.0,
   child: new Container(
-    child: new TranstionToImage(
+    child: new TransitionToImage(
       new AdvancedNetworkImage(url),
       // This is the default placeholder widget at loading status,
       // you can write your own widget with CustomPainter.


### PR DESCRIPTION
Ironically, there was a typo in my commit message as well.