### PR TITLE
Update TransitionToImage to use the placeholder

### DIFF
--- a/lib/transition_to_image.dart
+++ b/lib/transition_to_image.dart
@@ -179,7 +179,7 @@ class _TransitionToImageState extends State<TransitionToImage>
     }
 
     return (_status == _TransitionStatus.loading)
-        ? Center(child: CircularProgressIndicator())
+        ? Center(child: widget.placeholder)
         : (widget.transitionType == TransitionType.fade)
             ? FadeTransition(
                 opacity: _fadeTween.animate(_animation),


### PR DESCRIPTION
Update TransitionToImage to use the supplied placeholder instead of the hardcoded `CircularProgressIndicator` to conform to the expected behaviour