### PR TITLE
debugPrint doesn't accept Exception

### DIFF
--- a/lib/flutter_advanced_networkimage.dart
+++ b/lib/flutter_advanced_networkimage.dart
@@ -108,7 +108,7 @@ class AdvancedNetworkImage extends ImageProvider<AdvancedNetworkImage> {
         return await ui.instantiateImageCodec(_diskCache);
       }
     } catch (e) {
-      debugPrint(e);
+      print(e);
     }
 
     Uint8List imageData = await _loadFromRemote(


### PR DESCRIPTION
first parameter is a String, so it throws an error while catching another error