### PR TITLE
Improved performance of progress-tracked http image download

### DIFF
--- a/lib/src/transition/transition_to_image.dart
+++ b/lib/src/transition/transition_to_image.dart
@@ -359,11 +359,11 @@ class _TransitionToImageState extends State<TransitionToImage>
         widget.loadingWidgetBuilder != null) {
       var callback = (_imageProvider as AdvancedNetworkImage).loadingProgress;
       (_imageProvider as AdvancedNetworkImage).loadingProgress =
-          (double progress, List<int> data) {
+          (double progress, Uint8List data) {
         if (mounted) {
           setState(() {
             _progress = progress;
-            if (progress > 0.1) _imageData = Uint8List.fromList(data);
+            if (progress > 0.1) _imageData = data;
           });
         } else {
           return oldImageStream?.removeListener(


### PR DESCRIPTION
I noticed that the images loads several time slower when I enable progress tracking with loadingWidgetBuilder.
This commit brings huge performance improvements to progress-tracked http image downloads by using Uint8List as a buffer instead of an integer list.