### PR TITLE
Add public getter for current size in bytes

### DIFF
--- a/lib/src/disk_cache.dart
+++ b/lib/src/disk_cache.dart
@@ -99,7 +99,7 @@ class DiskCache {
 
   Future<void> _commitMetaData([bool force = false]) async {
     if (!force) {
-      if (currentEntries < maxEntries && _currentSizeBytes < maxEntries) return;
+      if (currentEntries < maxEntries && _currentSizeBytes < maxSizeBytes) return;
       _currentOps += 1;
       if (_currentOps < maxCommitOps) return;
     }

--- a/lib/src/disk_cache.dart
+++ b/lib/src/disk_cache.dart
@@ -73,9 +73,12 @@ class DiskCache {
   int _currentOps = 0;
 
   int get currentEntries => _metadata != null ? _metadata.keys.length : 0;
+  int get currentSizeBytes => _currentSizeBytes;
   int get _currentSizeBytes {
     int size = 0;
-    _metadata.values.forEach((item) => size += item['size']);
+    if (_metadata != null) {
+      _metadata.values.forEach((item) => size += item['size']);
+    }
     return size;
   }
 


### PR DESCRIPTION
Useful for configuring the max bytes to a meaningful value.

Also, when committing metadata, `_currentSizeBytes` was compared against `maxEntries`, not `maxSizeBytes`, which I assume is an error, leading the check to fail every time for common image sizes.